### PR TITLE
Bug/cli generate hash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ target-version = ['py312']
 
 
 [tool.bumpver]
-current_version = "0.2.3"
+current_version = "0.2.4"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = true

--- a/src/manifestly/__init__.py
+++ b/src/manifestly/__init__.py
@@ -3,7 +3,7 @@ Manifestly is a Python library for creating and managing manifest files.
 """
 from .core import Manifest
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 
 def get_version():

--- a/src/manifestly/cli.py
+++ b/src/manifestly/cli.py
@@ -11,6 +11,7 @@ Usage:
 import click
 import fsspec
 
+from manifestly import settings
 from .core import Manifest
 
 
@@ -25,7 +26,7 @@ def cli():
 
 @cli.command('generate')
 @click.argument('directory')
-@click.option('--hash-algorithm', default='sha256')
+@click.option('--hash-algorithm', default=settings.DEFAULT_HASH_ALGORITHM)
 @click.option('--output-file', default=None)
 def generate_cmd(directory, hash_algorithm, output_file):
     """


### PR DESCRIPTION
The cli generate command has a kwarg that allows you to override the hash, but it hard codes sha256 instead of using the settings value. 